### PR TITLE
Remove audioscrobbler from fanboy annoyances

### DIFF
--- a/fanboy-addon/fanboy_annoyance_thirdparty.txt
+++ b/fanboy-addon/fanboy_annoyance_thirdparty.txt
@@ -345,7 +345,6 @@
 ||wishpond.com^$third-party,domain=~markanthonywineandspirits.ca
 ||worldgravity.com^$third-party
 ||wp.com/www.feedburner.com/fb/$image
-||ws.audioscrobbler.com^$third-party,domain=~play.google.com|~spotify.com
 ||xhamsterlive.com/api/external/$third-party
 ||yimg.com/uq/syndication/
 ||yimg.com^*/GoldenGate.


### PR DESCRIPTION
Issue: https://github.com/easylist/easylist/issues/19533

This is not an annoyance, it's important and desired functionality for people who use last.fm